### PR TITLE
Set pwquality.conf with variable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -377,6 +377,18 @@ ubuntu1804cis_sshd:
   # denyusers:
   # denygroups:
 
+ubuntu1804cis_pwquality:
+  - key: 'minlen'
+    value: '14'
+  - key: 'dcredit'
+    value: '-1'
+  - key: 'ucredit'
+    value: '-1'
+  - key: 'ocredit'
+    value: '-1'
+  - key: 'lcredit'
+    value: '-1'
+
 ubuntu1804cis_pass:
   max_days: 90
   min_days: 7

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -442,11 +442,7 @@
             regexp: '^{{ item.key }}'
             line: '{{ item.key }} = {{ item.value }}'
         with_items:
-            - { key: 'minlen', value: '14' }
-            - { key: 'dcredit', value: '-1' }
-            - { key: 'ucredit', value: '-1' }
-            - { key: 'ocredit', value: '-1' }
-            - { key: 'lcredit', value: '-1' }
+            - "{{ ubuntu1804cis_pwquality }}"
   when:
       - ubuntu1804cis_rule_5_3_1
   tags:


### PR DESCRIPTION
Use a variable named `ubuntu1804cis_pwquality` instead of harcoded values in the task to set up pwquality.conf file.